### PR TITLE
feat: Mac Compatibility Support & Documentation Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 .venv/
 venv/
+env/
+
 *.py[cod]
 model/
 models/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,99 @@
-> [!important]
-> Please prefer using commits from [release tags](https://github.com/truefoundry/llm-finetune/releases). `main` branch is work in progress and may have partially working commits.
+# LLM Finetuning Project
 
-## LLM Finetuning with Truefoundry
+> [!NOTE]
+> **Status**: Active Development. Supports Linux (Production) and Mac (Development/Fallback).
 
-Test QLoRA w/ Deepspeed Stage 2
+This project provides a robust pipeline for fine-tuning Large Language Models (LLMs) using **Axolotl**, **DeepSpeed**, and **Unsloth**. It is designed to be highly configurable and efficient, supporting the latest optimization techniques like QLoRA and Flash Attention 2.
 
+## 🚀 Key Features
+
+-   **High Performance**: Leverages `unsloth` and `flash-attention` for faster training on NVIDIA GPUs.
+-   **Multi-Platform Support**: functionality on **Linux** (Production) and **macOS** (Development via Fallback Compatibility Layer).
+-   **Experiment Tracking**: Integrated with **TrueFoundry** and **TensorBoard** for metrics and model management.
+-   **Modular Configuration**: Easy-to-use YAML configuration for models, datasets, and hyperparameters.
+
+---
+
+## 🛠️ Installation
+
+### 1. Linux (Production / NVIDIA GPU)
+This is the recommended way to run full fine-tuning jobs.
+
+**Prerequisites:**
+-   Linux OS
+-   NVIDIA GPU with CUDA 12.x
+-   Docker (Optional but recommended)
+
+**Using Docker (Recommended):**
+```bash
+docker build -t llm-finetune .
+docker run --gpus all -it llm-finetune
 ```
-./sample_run.sh
+
+**Local Install:**
+```bash
+pip install -r base-requirements.txt
+pip install -r requirements.txt
+```
+
+### 2. macOS (Apple Silicon / Development)
+Run the project on your Mac for development, debugging, and testing the pipeline.
+*Note: Advanced optimizations (Unsloth, DeepSpeed sharding) are disabled in this mode.*
+
+**Setup:**
+```bash
+# Create a virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Install Mac-compatible dependencies
+pip install -r requirements-mac.txt
 ```
 
 ---
 
-TODO:
+## 🏃 Usage
 
-- [ ] Setup C/I Tests
-- [ ] Track and publish VRAM and Speed benchmarks for popular models and GPUs
+### Quick Start (Dry Run)
+Verify your setup by running a small dry-run with GPT-2.
+
+```bash
+# Linux/Mac
+python train.py config-base.yaml \
+  --base_model gpt2 \
+  --output_dir ./outputs \
+  --max_steps 1 \
+  --train_data_uri ./sample_data/multiply-1k.jsonl
+```
+
+### Full Training
+Configure your training in `config-base.yaml` or pass arguments via CLI.
+
+```bash
+python train.py config-base.yaml \
+  --base_model unsloth/Llama-3.2-1B-Instruct \
+  --num_epochs 3 \
+  --learning_rate 2e-4
+```
 
 ---
 
-Generally we always try to optimize for memory footprint because that allows higher batch size and more gpu utilization
-Speedup is second priority but we take what we can easily get
+## 📂 Project Structure
+
+-   `train.py`: Main entry point. Contains the training loop and Mac compatibility layer.
+-   `utils.py`: Utility functions for memory management and GPU metrics.
+-   `config-base.yaml`: Base configuration file for Axolotl.
+-   `requirements.txt`: Production dependencies (Linux/CUDA).
+-   `requirements-mac.txt`: Development dependencies (Mac/MPS).
+-   `Dockerfile`: Container definition for reproducible builds.
+
+---
+
+## 🤝 Contributing
+
+Please ensure you test your changes on both Linux (if possible) and Mac environments.
+-   **Mac Users**: Use `requirements-mac.txt`.
+-   **Linux Users**: Use `requirements.txt`.
+
+---
+*Powered by [TrueFoundry](https://truefoundry.com/)*

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -1,0 +1,13 @@
+torch
+transformers
+peft
+accelerate
+bitsandbytes
+scipy
+fire
+pyyaml
+rich
+truefoundry
+cloud-files
+fsspec
+pyarrow


### PR DESCRIPTION
This PR introduces full compatibility for macOS (Apple Silicon) environments, allowing the training pipeline to be run in a development/debug mode without NVIDIA GPUs. It also includes a comprehensive overhaul of the documentation to clarify cross-platform usage and cleanup of project configuration.

Key Changes
Mac Compatibility Layer:
Modified 
train.py
 to gracefully handle missing Linux-specific dependencies (
axolotl
, deepspeed, unsloth).
Implemented a fallback training loop using standard HuggingFace Transformers when running on Mac.
Added shims for distributed training functions to allow single-process execution.
Patched 
utils.py
 to make pynvml (NVIDIA management library) optional and guard memory settings with CUDA availability checks.
Dependencies:
Added 
requirements-mac.txt
 for Apple Silicon compatible dependencies.
Documentation:
Overhauled 
README.md
 with clear, distinct instructions for "Linux (Production)" vs "macOS (Development)".
Added "Quick Start" section with dry-run commands.
Housekeeping:
Updated 
.gitignore
 to properly exclude virtual environment directories (venv, .venv, 
env
).
Verification
Mac/MPS: Verified successfully by running a dry-run training loop with gpt2 and sample data on a Mac environment.
bash
python train.py config-base.yaml --base_model gpt2 --output_dir ./outputs --max_steps 1
Linux/CUDA: Core logic for Linux remains strictly guarded and should function as before (logic only branches if 
axolotl
 import fails).
